### PR TITLE
fix(workflow): #11 review wf release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,11 +49,10 @@ jobs:
             echo "" >> changelog.txt
             git log --pretty=format:"* %s (%h)" $PREV_TAG..${{ env.VERSION }} >> changelog.txt
           fi
-          {
-            echo 'CHANGELOG<<EOF'
-            cat changelog.txt
-            echo 'EOF'
-          } >> $GITHUB_ENV
+          echo 'CHANGELOG<<EOF' >> $GITHUB_ENV
+          cat changelog.txt >> $GITHUB_ENV
+          echo '' >> $GITHUB_ENV
+          echo 'EOF' >> $GITHUB_ENV
           
       - name: Generate Module documentation
         run: |


### PR DESCRIPTION
Release wf was failing to autogenerate release, this was by an issue with a multiline env. fix: use the official multiline syntax for setting environment variables.