### PR TITLE
docs: add package docs, runnable examples, and coverage config

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,7 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ['1.21.x', '1.22.x', '1.23.x']
+        # Must stay at or above the version declared in go.mod.
+        go-version: ['1.24.x', '1.25.x', '1.26.x']
 
     steps:
     - uses: actions/checkout@v4
@@ -34,7 +35,7 @@ jobs:
     - name: Upload coverage report
       uses: codecov/codecov-action@v6
       with:
-        file: ./coverage.txt
+        files: ./coverage.txt
         fail_ci_if_error: false
         token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,13 +8,18 @@ This project follows standard Go package conventions:
 
 ```
 deidentify/
+├── doc.go              # Package documentation
 ├── deidentify.go       # Main package implementation
+├── data.go             # Replacement value tables (names, domains, streets)
+├── patterns.go         # Regular expressions used for PII detection
 ├── deidentify_test.go  # Package tests
-├── examples/           # Example usages
-│   ├── basic/
-│   │   └── main.go     # Simple text deidentification example
-│   └── table/
-│       └── main.go     # Table-based deidentification example
+├── example_test.go     # Runnable godoc examples
+├── benchmark_test.go   # Performance benchmarks
+├── examples/           # Example programs
+│   ├── basic/          # Simple text deidentification
+│   ├── table/          # Table-based deidentification
+│   ├── slices/         # CSV-like [][]string deidentification
+│   └── international/  # International address handling
 └── go.mod              # Module definition
 ```
 
@@ -43,14 +48,29 @@ The package exposes types and functions following Go's idiomatic practices:
 
 ### Core Types
 
-- `Deidentifier`: Interface for objects that can identify and redact PII
-- `Option`: Functional options for configuring deidentification behavior
+- `Deidentifier`: Replaces PII with deterministic, format-preserving substitutes. Safe for concurrent use.
+- `DataType`: The kind of PII a value holds (`TypeName`, `TypeEmail`, `TypePhone`, `TypeSSN`, `TypeCreditCard`, `TypeAddress`, `TypeGeneric`)
+- `Table` / `Column`: Column-oriented data to deidentify as a unit
 
-### Main Functions
+### Constructors
 
-- `New(options ...Option) *Deidentifier`: Creates a new deidentifier with specified options
-- `Deidentify(text string) (string, error)`: Processes text, returning a deidentified version
-- `DeidentifyBytes(data []byte) ([]byte, error)`: Processes byte data for binary-safe operations
+- `GenerateSecretKey() (string, error)`: Returns a hex-encoded 256-bit random key
+- `NewDeidentifier(secretKey string) *Deidentifier`: Creates a deidentifier bound to a secret key
+
+### Main Methods
+
+- `Text(text string) (string, error)`: Finds and replaces PII in free-form text
+- `Table(table *Table) (*Table, error)`: Deidentifies column-oriented data by declared type
+- `Slices(data [][]string, optional ...interface{}) ([][]string, error)`: Deidentifies CSV-like data, inferring column types when not supplied
+
+### Single-value Methods
+
+`Name`, `Email`, `Phone`, `SSN`, `CreditCard`, and `Address` each deidentify one
+value of a known type, returning `(string, error)`. `ClearMappings()` discards
+the accumulated mapping tables.
+
+Replacements are deterministic: the same input and secret key always produce the
+same output, which preserves referential integrity across records and runs.
 
 ## Development Guidelines
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Deidentify
 
-![Version](https://img.shields.io/github/v/release/aliengiraffe/deidentify.svg)
-[![Go Report Card](https://goreportcard.com/badge/github.com/aliengiraffe/deidentify?1=2)](https://goreportcard.com/report/github.com/aliengiraffe/deidentify)
-[![GoDoc](https://godoc.org/github.com/aliengiraffe/deidentify?status.svg)](https://godoc.org/github.com/aliengiraffe/deidentify)
-[![License](https://img.shields.io/github/license/aliengiraffe/deidentify.svg?1=1)](LICENSE)
-
-![Release](https://github.com/aliengiraffe/deidentify/actions/workflows/release.yml/badge.svg)
+[![Go Reference](https://pkg.go.dev/badge/github.com/aliengiraffe/deidentify.svg)](https://pkg.go.dev/github.com/aliengiraffe/deidentify)
+[![Go Report Card](https://goreportcard.com/badge/github.com/aliengiraffe/deidentify)](https://goreportcard.com/report/github.com/aliengiraffe/deidentify)
+[![codecov](https://codecov.io/gh/aliengiraffe/deidentify/branch/main/graph/badge.svg)](https://codecov.io/gh/aliengiraffe/deidentify)
+[![Build & Test](https://github.com/aliengiraffe/deidentify/actions/workflows/go.yml/badge.svg)](https://github.com/aliengiraffe/deidentify/actions/workflows/go.yml)
+[![Version](https://img.shields.io/github/v/release/aliengiraffe/deidentify.svg)](https://github.com/aliengiraffe/deidentify/releases)
+[![License](https://img.shields.io/github/license/aliengiraffe/deidentify.svg)](LICENSE)
 
 A Go library for detecting and removing personally identifiable information (PII) from text and structured data.
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,21 @@
+# Coverage is measured against the library itself. The programs under
+# examples/ are documentation that is compiled but not exercised by tests, so
+# including them would understate the coverage of the package.
+ignore:
+  - "examples/**"
+
+coverage:
+  status:
+    project:
+      default:
+        target: 80%
+        threshold: 2%
+    patch:
+      default:
+        target: 80%
+        threshold: 5%
+
+comment:
+  layout: "reach, diff, files"
+  behavior: default
+  require_changes: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -18,4 +18,4 @@ coverage:
 comment:
   layout: "reach, diff, files"
   behavior: default
-  require_changes: true
+  require_changes: false

--- a/deidentify.go
+++ b/deidentify.go
@@ -13,35 +13,53 @@ import (
 	"sync"
 )
 
-// DataType represents the type of personally identifiable information
+// DataType represents the type of personally identifiable information held by
+// a value, and determines which replacement strategy is applied to it.
 type DataType int
 
+// The PII types recognized by this package. Each type has a replacement
+// strategy that preserves the format of the original value.
 const (
+	// TypeName is a personal name, replaced with a generated first and last name.
 	TypeName DataType = iota
+	// TypeEmail is an email address, replaced with a generated address at a fictional domain.
 	TypeEmail
+	// TypePhone is a phone number, replaced while preserving punctuation and area code.
 	TypePhone
+	// TypeSSN is a US Social Security number, replaced with a structurally valid number.
 	TypeSSN
+	// TypeCreditCard is a credit card number, replaced with a number that passes the Luhn check.
 	TypeCreditCard
+	// TypeAddress is a street address, replaced with a generated street number and name.
 	TypeAddress
+	// TypeGeneric marks a value with no detected PII. Such values are returned unchanged.
 	TypeGeneric
 )
 
-// Column represents a single column in a table with its data type and values
+// Column represents a single column in a [Table]: its name, the type of PII it
+// holds, and its values. The name is used as replacement context, so identical
+// values in differently named columns receive different replacements.
 type Column struct {
-	Name     string
+	// Name identifies the column and scopes its replacement mappings.
+	Name string
+	// DataType is the kind of PII stored in this column.
 	DataType DataType
-	Values   []interface{}
+	// Values holds the column's cells. A nil element is passed through as nil.
+	Values []interface{}
 }
 
-// Deidentifier handles the deidentification of PII data
+// Deidentifier replaces PII with deterministic, format-preserving substitutes.
+// Create one with [NewDeidentifier]. A Deidentifier is safe for concurrent use
+// by multiple goroutines.
 type Deidentifier struct {
 	secretKey     []byte
 	mappingTables map[string]map[string]string
 	mutex         sync.RWMutex
 }
 
-// Table represents a collection of columns
+// Table represents column-oriented data to be deidentified as a unit.
 type Table struct {
+	// Columns are the table's columns, each carrying its own data type.
 	Columns []Column
 }
 
@@ -63,7 +81,10 @@ type slicesConfig struct {
 	numCols     int
 }
 
-// Address is a convenience method to deidentify a single address
+// Address deidentifies a single street address, replacing it with a generated
+// street number and name. It recognizes international address formats and
+// preserves a leading label, so "Europe HQ: 10 Rue de Rivoli, Paris, France"
+// keeps its "Europe HQ:" prefix.
 func (d *Deidentifier) Address(address string) (string, error) {
 	// Check for a label prefix (like "European HQ:") and extract the actual address part
 	address = strings.TrimSpace(address)
@@ -129,45 +150,62 @@ func (d *Deidentifier) Address(address string) (string, error) {
 	return deidentified, nil
 }
 
-// ClearMappings clears all stored mappings (useful for testing)
+// ClearMappings discards every stored value-to-replacement mapping. Because
+// replacements are derived from the secret key, clearing does not change what
+// a given input maps to; it only frees the accumulated mapping tables.
 func (d *Deidentifier) ClearMappings() {
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
 	d.mappingTables = make(map[string]map[string]string)
 }
 
-// CreditCard is a convenience method to deidentify a single credit card number
+// CreditCard deidentifies a single credit card number. The replacement is a
+// 16-digit test number that passes the Luhn checksum.
 func (d *Deidentifier) CreditCard(cc string) (string, error) {
 	return d.deidentifyValue(cc, TypeCreditCard, "credit_card")
 }
 
-// Email is a convenience method to deidentify a single email
+// Email deidentifies a single email address, replacing it with a generated
+// address at a fictional domain.
 func (d *Deidentifier) Email(email string) (string, error) {
 	return d.deidentifyValue(email, TypeEmail, "email")
 }
 
-// Name is a convenience method to deidentify a single name
+// Name deidentifies a single personal name, replacing it with a generated
+// first and last name.
 func (d *Deidentifier) Name(name string) (string, error) {
 	return d.deidentifyValue(name, TypeName, "name")
 }
 
-// Phone is a convenience method to deidentify a single phone number
+// Phone deidentifies a single phone number, preserving its punctuation and
+// area code. Input that cannot be parsed as a phone number is replaced with an
+// opaque generic value.
 func (d *Deidentifier) Phone(phone string) (string, error) {
 	return d.deidentifyValue(phone, TypePhone, "phone")
 }
 
-// SSN is a convenience method to deidentify a single SSN
+// SSN deidentifies a single US Social Security number, replacing it with a
+// structurally valid number in AAA-GG-SSSS form.
 func (d *Deidentifier) SSN(ssn string) (string, error) {
 	return d.deidentifyValue(ssn, TypeSSN, "ssn")
 }
 
-// Slices processes a slice of string slices ([][]string)
-// Each inner slice represents a row of data
-// Optional parameters:
-//   - columnTypes: DataType for each column (will infer if not provided)
-//   - columnNames: names for each column (will generate if not provided)
+// Slices deidentifies CSV-like data, where each inner slice is a row. It
+// returns a new [][]string of the same shape; empty cells are left empty.
 //
-// Usage: Slices(data) or Slices(data, columnTypes) or Slices(data, columnTypes, columnNames)
+// Two optional arguments may follow data, in order:
+//
+//   - columnTypes ([]DataType): the type of each column. When omitted, the
+//     type of every column is inferred by sampling its values.
+//   - columnNames ([]string): the name of each column, used as replacement
+//     context. When omitted, names of the form "column_0" are generated.
+//
+// Both must have one entry per column, or Slices returns an error. Passing an
+// argument of any other type is also an error.
+//
+//	d.Slices(data)
+//	d.Slices(data, columnTypes)
+//	d.Slices(data, columnTypes, columnNames)
 func (d *Deidentifier) Slices(data [][]string, optional ...interface{}) ([][]string, error) {
 	if len(data) == 0 {
 		return [][]string{}, nil
@@ -181,7 +219,9 @@ func (d *Deidentifier) Slices(data [][]string, optional ...interface{}) ([][]str
 	return d.processSliceData(data, config)
 }
 
-// Table processes an entire table
+// Table deidentifies every column of a table according to its declared
+// [DataType], returning a new [Table] and leaving the input untouched. Nil
+// values are preserved as nil.
 func (d *Deidentifier) Table(table *Table) (*Table, error) {
 	result := &Table{
 		Columns: make([]Column, len(table.Columns)),
@@ -214,7 +254,10 @@ func (d *Deidentifier) Table(table *Table) (*Table, error) {
 	return result, nil
 }
 
-// Text identifies and deidentifies PII from a text string
+// Text finds and replaces PII in free-form text, returning the redacted text.
+// It detects email addresses, phone numbers, Social Security numbers, credit
+// card numbers, names, and street addresses. Detection is pattern-based and is
+// not guaranteed to be exhaustive.
 func (d *Deidentifier) Text(text string) (string, error) {
 	if text == "" {
 		return "", nil
@@ -233,7 +276,11 @@ func (d *Deidentifier) Text(text string) (string, error) {
 	return result, nil
 }
 
-// GenerateSecretKey generates a cryptographically secure random key
+// GenerateSecretKey returns a cryptographically secure random 256-bit key,
+// hex-encoded, suitable for passing to [NewDeidentifier].
+//
+// Store the key if you need replacements to stay consistent across runs:
+// deidentifying the same data with a different key produces different output.
 func GenerateSecretKey() (string, error) {
 	key := make([]byte, 32)
 	_, err := rand.Read(key)
@@ -243,7 +290,9 @@ func GenerateSecretKey() (string, error) {
 	return hex.EncodeToString(key), nil
 }
 
-// NewDeidentifier creates a new deidentifier with a secret key
+// NewDeidentifier returns a [Deidentifier] that derives its replacements from
+// secretKey. Use [GenerateSecretKey] to create one, and reuse the same key
+// whenever deidentified values must match across runs or datasets.
 func NewDeidentifier(secretKey string) *Deidentifier {
 	return &Deidentifier{
 		secretKey:     []byte(secretKey),

--- a/deidentify_test.go
+++ b/deidentify_test.go
@@ -826,3 +826,221 @@ func BenchmarkSlicesDeidentification(b *testing.B) {
 		}
 	}
 }
+
+func TestNameMethod(t *testing.T) {
+	d := NewDeidentifier("test-secret-key")
+
+	original := "Frodo Baggins"
+	result, err := d.Name(original)
+	if err != nil {
+		t.Fatalf("Name failed: %v", err)
+	}
+	if result == original {
+		t.Errorf("Name should be anonymized, got the original value: %s", result)
+	}
+	if !regexp.MustCompile(`^[A-Za-z]+ [A-Za-z]+$`).MatchString(result) {
+		t.Errorf("Name result %q doesn't look like a first/last name pair", result)
+	}
+
+	// The same input must map to the same replacement.
+	again, err := d.Name(original)
+	if err != nil {
+		t.Fatalf("Name failed on second call: %v", err)
+	}
+	if again != result {
+		t.Errorf("Name is not deterministic: got %q then %q", result, again)
+	}
+}
+
+func TestCreditCardMethod(t *testing.T) {
+	d := NewDeidentifier("test-secret-key")
+
+	original := "4111-1111-1111-1111"
+	result, err := d.CreditCard(original)
+	if err != nil {
+		t.Fatalf("CreditCard failed: %v", err)
+	}
+	if result == original {
+		t.Errorf("CreditCard should be anonymized, got the original value: %s", result)
+	}
+
+	digits := regexp.MustCompile(`\D`).ReplaceAllString(result, "")
+	if len(digits) != 16 {
+		t.Errorf("Expected 16 digits, got %d in %q", len(digits), result)
+	}
+	if !isValidLuhn(digits) {
+		t.Errorf("Generated card %q fails the Luhn checksum", result)
+	}
+}
+
+func TestAddressMethod(t *testing.T) {
+	d := NewDeidentifier("test-secret-key")
+
+	// Each input exercises a different branch of Address: the three special
+	// international patterns and the standard fallback. The "labeled" variants
+	// carry a "Label:" prefix that must be preserved in the output.
+	testCases := []struct {
+		name    string
+		address string
+		label   string
+	}{
+		{"special pattern 1", "123 Orchard Road, Singapore", ""},
+		{"special pattern 2", "10 Grande Rue de Rivoli, Paris, France", ""},
+		{"special pattern 3", "at 123 Main Street", ""},
+		{"standard fallback", "1 Bagshot Row", ""},
+		{"labeled pattern 1", "Asia office: 123 Orchard Road, Singapore", "Asia office:"},
+		{"labeled pattern 2", "Europe HQ: 10 Grande Rue de Rivoli, Paris, France", "Europe HQ:"},
+		{"labeled pattern 3", "Note: at 123 Main Street", "Note:"},
+		{"labeled fallback", "Home: 1 Bagshot Row", "Home:"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := d.Address(tc.address)
+			if err != nil {
+				t.Fatalf("Address failed: %v", err)
+			}
+			if result == tc.address {
+				t.Errorf("Address should be anonymized, got the original value: %s", result)
+			}
+			if tc.label != "" && !strings.HasPrefix(result, tc.label+" ") {
+				t.Errorf("Expected label %q to be preserved, got %q", tc.label, result)
+			}
+		})
+	}
+}
+
+func TestClearMappings(t *testing.T) {
+	d := NewDeidentifier("test-secret-key")
+
+	original := "test@example.com"
+	if _, err := d.Email(original); err != nil {
+		t.Fatalf("Email failed: %v", err)
+	}
+	if d.getMapping("email", original) == "" {
+		t.Fatal("Expected a stored mapping after deidentifying a value")
+	}
+
+	d.ClearMappings()
+
+	if mapped := d.getMapping("email", original); mapped != "" {
+		t.Errorf("Expected mappings to be cleared, still found %q", mapped)
+	}
+}
+
+func TestGenerateGeneric(t *testing.T) {
+	d := NewDeidentifier("test-secret-key")
+
+	result := d.generateGeneric("some-unstructured-value")
+	if !regexp.MustCompile(`^DATA_[0-9a-f]{16}$`).MatchString(result) {
+		t.Errorf("Generic result %q doesn't match the DATA_<hex> format", result)
+	}
+	if result != d.generateGeneric("some-unstructured-value") {
+		t.Error("generateGeneric should be deterministic")
+	}
+	if result == d.generateGeneric("a-different-value") {
+		t.Error("Different inputs should produce different generic values")
+	}
+
+	// An unrecognized DataType falls through to the generic replacement.
+	viaSwitch, err := d.deidentifyValue("value", DataType(99), "column")
+	if err != nil {
+		t.Fatalf("deidentifyValue failed: %v", err)
+	}
+	if !strings.HasPrefix(viaSwitch, "DATA_") {
+		t.Errorf("Unknown DataType should produce a generic value, got %q", viaSwitch)
+	}
+}
+
+func TestGeneratePhoneFallback(t *testing.T) {
+	d := NewDeidentifier("test-secret-key")
+
+	// A string the phone format regex cannot parse falls back to generic data.
+	result := d.generatePhone("12")
+	if !strings.HasPrefix(result, "DATA_") {
+		t.Errorf("Expected a generic fallback for an unparseable phone, got %q", result)
+	}
+}
+
+func TestHashToIndexEdgeCases(t *testing.T) {
+	d := NewDeidentifier("test-secret-key")
+
+	if got := d.hashToIndex(nil, 10); got != 0 {
+		t.Errorf("Expected 0 for empty hash bytes, got %d", got)
+	}
+	if got := d.hashToIndex([]byte{}, 10); got != 0 {
+		t.Errorf("Expected 0 for empty hash bytes, got %d", got)
+	}
+	if got := d.hashToIndex([]byte{1, 2, 3}, 0); got != 0 {
+		t.Errorf("Expected 0 for a zero max, got %d", got)
+	}
+	if got := d.hashToIndex([]byte{1, 2, 3}, -5); got != 0 {
+		t.Errorf("Expected 0 for a negative max, got %d", got)
+	}
+
+	// Valid input must stay within [0, max).
+	hash := d.deterministicHash("value")
+	for range 100 {
+		if got := d.hashToIndex(hash[:8], 7); got < 0 || got >= 7 {
+			t.Fatalf("Index %d out of range [0,7)", got)
+		}
+	}
+}
+
+func TestInferColumnTypesEmptyData(t *testing.T) {
+	d := NewDeidentifier("test-secret-key")
+
+	types, err := d.inferColumnTypes([][]string{})
+	if err != nil {
+		t.Fatalf("inferColumnTypes failed: %v", err)
+	}
+	if len(types) != 0 {
+		t.Errorf("Expected no column types for empty data, got %d", len(types))
+	}
+}
+
+func TestEmptyValueHandling(t *testing.T) {
+	d := NewDeidentifier("test-secret-key")
+
+	result, err := d.deidentifyValue("", TypeEmail, "email")
+	if err != nil {
+		t.Fatalf("deidentifyValue failed: %v", err)
+	}
+	if result != "" {
+		t.Errorf("Expected an empty string to pass through unchanged, got %q", result)
+	}
+
+	text, err := d.Text("")
+	if err != nil {
+		t.Fatalf("Text failed: %v", err)
+	}
+	if text != "" {
+		t.Errorf("Expected empty text to pass through unchanged, got %q", text)
+	}
+}
+
+func TestTextWithInternationalAddresses(t *testing.T) {
+	d := NewDeidentifier("test-secret-key")
+
+	// Exercises the special international address patterns inside Text.
+	testCases := []struct {
+		name    string
+		text    string
+		wantOut string
+	}{
+		{"country-suffixed address", "The office is 123 Orchard Road, Singapore today.", "123 Orchard Road"},
+		{"city and country address", "Ship to 10 Grande Rue de Rivoli, Paris, France now.", "Grande Rue de Rivoli"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := d.Text(tc.text)
+			if err != nil {
+				t.Fatalf("Text failed: %v", err)
+			}
+			if strings.Contains(result, tc.wantOut) {
+				t.Errorf("Expected %q to be removed from the output, got %q", tc.wantOut, result)
+			}
+		})
+	}
+}

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,65 @@
+/*
+Package deidentify removes personally identifiable information (PII) from text
+and structured data while preserving the shape and utility of the original data.
+
+Replacements are deterministic: the same input, deidentified with the same
+secret key, always yields the same output. This preserves referential integrity
+across records and runs, so joins and groupings still work on anonymized data.
+Different secret keys produce different outputs, so the mapping cannot be
+reproduced without the key.
+
+# Getting started
+
+Create a Deidentifier with a secret key and call [Deidentifier.Text] to redact
+free-form text:
+
+	secretKey, err := deidentify.GenerateSecretKey()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	d := deidentify.NewDeidentifier(secretKey)
+
+	redacted, err := d.Text("Contact Frodo Baggins at frodo@shire.me or (555) 123-4567.")
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(redacted)
+
+# Supported PII types
+
+The package detects and replaces names, email addresses, phone numbers, Social
+Security numbers, credit card numbers, and street addresses. Each has a
+corresponding [DataType] constant and a convenience method on [Deidentifier]
+for deidentifying a single value of a known type.
+
+Replacements preserve the format of the original value. Phone numbers keep
+their punctuation and area code, credit card numbers keep a valid Luhn
+checksum, and SSNs keep a structurally valid area-group-serial layout.
+
+# Structured data
+
+[Deidentifier.Table] processes column-oriented data where the type of each
+column is known, and [Deidentifier.Slices] processes CSV-like [][]string data,
+inferring the type of each column when it is not supplied. Both use the column
+name as part of the replacement context, so the same value appearing in two
+different columns maps to two different replacements. This prevents correlation
+across columns.
+
+Values of type [TypeGeneric] are returned unchanged, which is how columns with
+no detected PII pass through the pipeline intact.
+
+# Concurrency
+
+A [Deidentifier] is safe for concurrent use by multiple goroutines. Its
+internal mapping tables are guarded by a mutex.
+
+# Limitations
+
+Detection is pattern-based. No automated system can guarantee that it finds
+every piece of PII, particularly in unstructured text, so results should be
+verified in sensitive applications. By default, phone area codes are preserved
+because they usually indicate a geographic region rather than an individual;
+consider whether that tradeoff suits your threat model.
+*/
+package deidentify

--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,171 @@
+package deidentify_test
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/aliengiraffe/deidentify"
+)
+
+// The examples below assert on stable properties rather than on the generated
+// values themselves, because the exact replacement chosen for a given input
+// depends on the secret key.
+
+func ExampleNewDeidentifier() {
+	// In production, generate a key once with GenerateSecretKey and store it.
+	// Reusing the same key keeps replacements consistent across runs.
+	d := deidentify.NewDeidentifier("example-secret-key")
+
+	redacted, err := d.Text("Please email Frodo Baggins at frodo.baggins@shire.me or call (555) 123-4567.")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// redacted reads, for example:
+	// "Please email Marlo Cole at undefined6840@private.com or call (555) 777-3471."
+	fmt.Println(strings.Contains(redacted, "Frodo Baggins"))
+	fmt.Println(strings.Contains(redacted, "frodo.baggins@shire.me"))
+	fmt.Println(strings.Contains(redacted, "(555) 123-4567"))
+	// Output:
+	// false
+	// false
+	// false
+}
+
+func ExampleGenerateSecretKey() {
+	secretKey, err := deidentify.GenerateSecretKey()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// The key is a hex-encoded 256-bit value.
+	fmt.Println(len(secretKey))
+	// Output: 64
+}
+
+func ExampleDeidentifier_Email() {
+	d := deidentify.NewDeidentifier("example-secret-key")
+
+	first, err := d.Email("bilbo@bag-end.shire")
+	if err != nil {
+		log.Fatal(err)
+	}
+	second, err := d.Email("bilbo@bag-end.shire")
+	if err != nil {
+		log.Fatal(err)
+	}
+	other, err := d.Email("frodo@shire.me")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// The same address always maps to the same replacement, so records can
+	// still be joined on the anonymized value.
+	fmt.Println(first == second)
+	fmt.Println(first == other)
+	fmt.Println(strings.Contains(first, "@"))
+	// Output:
+	// true
+	// false
+	// true
+}
+
+func ExampleDeidentifier_Phone() {
+	d := deidentify.NewDeidentifier("example-secret-key")
+
+	redacted, err := d.Phone("(555) 123-4567")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Punctuation and area code are preserved; only the subscriber digits change.
+	fmt.Println(strings.HasPrefix(redacted, "(555) "))
+	fmt.Println(len(redacted) == len("(555) 123-4567"))
+	fmt.Println(redacted == "(555) 123-4567")
+	// Output:
+	// true
+	// true
+	// false
+}
+
+func ExampleDeidentifier_Table() {
+	d := deidentify.NewDeidentifier("example-secret-key")
+
+	table := &deidentify.Table{
+		Columns: []deidentify.Column{
+			{
+				Name:     "customer_name",
+				DataType: deidentify.TypeName,
+				Values:   []interface{}{"Gandalf Grey", nil},
+			},
+			{
+				Name:     "email",
+				DataType: deidentify.TypeEmail,
+				Values:   []interface{}{"mithrandir@wizard.com", ""},
+			},
+		},
+	}
+
+	result, err := d.Table(table)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Nil and empty values pass through untouched.
+	fmt.Println(result.Columns[0].Values[0] == "Gandalf Grey")
+	fmt.Println(result.Columns[0].Values[1] == nil)
+	fmt.Println(result.Columns[1].Values[1] == "")
+	// Output:
+	// false
+	// true
+	// true
+}
+
+func ExampleDeidentifier_Slices() {
+	d := deidentify.NewDeidentifier("example-secret-key")
+
+	data := [][]string{
+		{"Gandalf Grey", "mithrandir@wizard.com", "555-123-4567"},
+		{"Aragorn Strider", "ranger@gondor.me", "(555) 987-6543"},
+	}
+
+	// With no column types supplied, each column's type is inferred.
+	result, err := d.Slices(data)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println(len(result), len(result[0]))
+	fmt.Println(result[0][1] == "mithrandir@wizard.com")
+	fmt.Println(strings.Contains(result[0][1], "@"))
+	// Output:
+	// 2 3
+	// false
+	// true
+}
+
+func ExampleDeidentifier_Slices_explicitTypes() {
+	d := deidentify.NewDeidentifier("example-secret-key")
+
+	data := [][]string{
+		{"Gandalf Grey", "mithrandir@wizard.com"},
+		{"Aragorn Strider", "ranger@gondor.me"},
+	}
+
+	// Supplying types skips inference; supplying names controls the context
+	// used for replacement, so the same value in two columns differs.
+	columnTypes := []deidentify.DataType{deidentify.TypeName, deidentify.TypeEmail}
+	columnNames := []string{"customer_name", "customer_email"}
+
+	result, err := d.Slices(data, columnTypes, columnNames)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println(result[0][0] == "Gandalf Grey")
+	fmt.Println(len(result))
+	// Output:
+	// false
+	// 2
+}


### PR DESCRIPTION
## Summary

A documentation, coverage, and CI-hygiene pass over the package. **No behavior changes to the library** — the only edits to `deidentify.go` are doc comments and struct field alignment.

## Documentation

- **`doc.go`** (new): package overview covering the determinism guarantee and why it matters (referential integrity across records and runs), a getting-started snippet, the supported PII types, and structured-data usage.
- **`example_test.go`** (new): runnable godoc examples for `NewDeidentifier`, `GenerateSecretKey`, `Email`, `Phone`, `Table`, and `Slices` (both inferred and explicit column types).
- **`deidentify.go`**: doc comments on every exported type, field, and method. Each `DataType` constant now documents its replacement strategy, and `Slices`' variadic contract is spelled out — `columnTypes` then `columnNames`, one entry per column, error otherwise.
- **`CLAUDE.md`**: the API Overview described an API that does not exist (`New(options ...Option)`, `Deidentify()`, `DeidentifyBytes()`). Replaced with the real one (`NewDeidentifier`, `Text`, `Table`, `Slices`), plus an updated project tree.
- **`README.md`**: badges reworked — deprecated godoc.org replaced with pkg.go.dev, codecov and build badges added, cache-busting query strings removed.

## Coverage

- **`deidentify_test.go`**: 10 new tests over previously untested paths — the `Name`/`CreditCard`/`Address` convenience methods, `ClearMappings`, generic and phone-fallback generation, `hashToIndex` edge cases, empty-data type inference, empty-value handling, and international addresses in `Text`.
- **`codecov.yml`** (new): 80% project and patch targets. Ignores `examples/**`, since those programs are compiled but never exercised by tests and would understate package coverage.

## CI

- **`.github/workflows/go.yml`**: test matrix bumped from 1.21–1.23 to 1.24.x–1.26.x. The old matrix tested below `go.mod`'s `go 1.24.2`; a comment now records that it must stay at or above that. Also renames the codecov action's deprecated `file` input to `files`.

## Test plan

- `gofmt -l .` — clean
- `go vet ./...` — clean
- `go test ./...` — passes
- CI matrix versions verified consistent with `go.mod` (`go 1.24.2`)
