### PR TITLE
docs: add the Mentioned in Awesome Go badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Build & Test](https://github.com/aliengiraffe/deidentify/actions/workflows/go.yml/badge.svg)](https://github.com/aliengiraffe/deidentify/actions/workflows/go.yml)
 [![Version](https://img.shields.io/github/v/release/aliengiraffe/deidentify.svg)](https://github.com/aliengiraffe/deidentify/releases)
 [![License](https://img.shields.io/github/license/aliengiraffe/deidentify.svg)](LICENSE)
+[![Mentioned in Awesome Go](https://awesome.re/mentioned-badge-flat.svg)](https://github.com/avelino/awesome-go)
 
 A Go library for detecting and removing personally identifiable information (PII) from text and structured data.
 


### PR DESCRIPTION
## Summary

Adds the "Mentioned in Awesome Go" badge to the README badge block, now that `deidentify` is listed in [awesome-go](https://github.com/avelino/awesome-go) under `## Security` ([avelino/awesome-go#6561](https://github.com/avelino/awesome-go/pull/6561)).

One line appended after the License badge:

```markdown
[![Mentioned in Awesome Go](https://awesome.re/mentioned-badge-flat.svg)](https://github.com/avelino/awesome-go)
```

Uses the **flat** variant so it lines up with the five existing flat shields-style badges, links to the awesome-go repo root (not the `#security` anchor, which is more prone to rot), and keeps one badge per line.

## Verification

- `curl -sSI -L https://awesome.re/mentioned-badge-flat.svg` → `200 image/svg+xml`; link target `https://github.com/avelino/awesome-go` → `200`.
- `git diff --stat` → `README.md | 1 +`, single file, single insertion.
- The five pre-existing badges are byte-for-byte unchanged and in their original order; no Go Report Card badge reintroduced.
- Sanity checks (this change cannot affect them, run anyway): `gofmt -l .` clean, `go vet ./...` clean, `golangci-lint run` → 0 issues, `go test ./...` → ok.

No test was added — there is no automated coverage for README content, and the issue explicitly asks not to invent one. Render check is on this PR page.

Closes #50