### PR TITLE
chore(renovate): disable Dependency Dashboard issue

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,6 @@
   "extends": [
     "config:recommended"
   ],
+  "dependencyDashboard": false,
   "dependencyDashboardAutoclose": true
 }


### PR DESCRIPTION
## Summary
- Add `"dependencyDashboard": false` to `renovate.json` so Renovate stops creating/reopening the Dependency Dashboard issue.
- `dependencyDashboardAutoclose` only auto-closes the dashboard once it has nothing left to report; it does not prevent Renovate from creating or reopening it, which is why issue #3 stays open.
- `extends: ["config:recommended"]` and all other Renovate settings are unchanged.

Closes #53

## Test plan
- [x] `python3 -m json.tool renovate.json` — confirms valid JSON
- [x] `npx --yes --package renovate -- renovate-config-validator renovate.json` — confirms the config validates against the Renovate schema ("Config validated successfully")
- [ ] Manual: confirm on the next scheduled Renovate run that no new Dependency Dashboard content is posted/updated on this repository